### PR TITLE
Workaround for #3

### DIFF
--- a/com/dtmilano/android/viewclient.py
+++ b/com/dtmilano/android/viewclient.py
@@ -2534,16 +2534,13 @@ class ViewClient:
 
         progname = os.path.basename(sys.argv[0])
         if serialno is None:
-            # droidbot
-            # @Lynn modified
-            # eat all the extra options the invoking script may have added
-            # args = sys.argv
-            # while len(args) > 1 and args[1][0] == '-':
-            #     args.pop(1)
-            # serialno = args[1] if len(args) > 1 else \
-            #         os.environ['ANDROID_SERIAL'] if os.environ.has_key('ANDROID_SERIAL') \
-            #         else '.*'
-            serialno = '.*'
+            #eat all the extra options the invoking script may have added
+            args = sys.argv
+            while len(args) > 1 and args[1][0] == '-':
+                args.pop(1)
+            serialno = args[1] if len(args) > 1 else \
+                    os.environ['ANDROID_SERIAL'] if os.environ.has_key('ANDROID_SERIAL') \
+                    else '.*'
         if IP_RE.match(serialno):
             # If matches an IP address format and port was not specified add the default
             serialno += ':%d' % ADB_DEFAULT_PORT

--- a/droidbot/droidbot.py
+++ b/droidbot/droidbot.py
@@ -33,6 +33,10 @@ class DroidBot(object):
             self.options.output_dir = "droidbot_out"
         if not os.path.exists(self.options.output_dir):
             os.mkdir(self.options.output_dir)
+        if self.options.device_serial is None:
+            # Dirty Workaround: Set device_serial to Default='.*', because com/dtmilano/android/viewclient.py
+            #  set serial to an arbitrary argument. IN connectToDeviceOrExit(..) line 2539f.
+            self.options.device_serial = '.*'
         DroidBot.instance = self
 
     @staticmethod


### PR DESCRIPTION
I don't know if this is a good fix. But I think your and my fix does the same, it sets 
```
if serialno is None:
    serialno = '.*'
```
The advantage of my workaround is, that we does not change the external code. If we want to update the external code, it would be easier. Perhaps there is also another way, then copying the external code into the droidbot repository.